### PR TITLE
Json deserialization issue

### DIFF
--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -762,7 +762,8 @@ namespace Dicom.Serialization
             var childValues = new List<T>();
             foreach (var item in tokens)
             {
-                if (!(item.Type == JTokenType.Float || item.Type == JTokenType.Integer)) { throw new JsonReaderException("Malformed DICOM json"); }
+                if (!(item.Type == JTokenType.String  && item.Value<string>() == "NaN") && !(item.Type  == JTokenType.Float || item.Type == JTokenType.Integer))
+                { throw new JsonReaderException("Malformed DICOM json"); }
                 childValues.Add((T)Convert.ChangeType(item.Value<object>(), typeof(T)));
             }
             var data = childValues.ToArray();

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -70,6 +70,23 @@ namespace FellowOakDicom.Tests.Serialization
         }
 
         [Fact]
+        public void ParseDoubleNaNValues()
+        {
+
+            var json = @"
+            {
+                ""00720076"": {
+                    ""vr"": ""FL"",
+                     ""Value"": [""NaN""]
+                 }
+            } ";
+
+            var tagValue = JsonConvert.DeserializeObject<DicomDataset>(json, new CustomJsonDicomConverter());
+            Assert.NotNull(tagValue);
+            Assert.NotNull(tagValue.GetDicomItem<DicomFloatingPointSingle>(DicomTag.SelectorFLValue));
+        }
+
+        [Fact]
         public void TimeParseTag()
         {
             var millisecondsPerCallA = TimeCall(100, () =>

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -72,7 +72,6 @@ namespace FellowOakDicom.Tests.Serialization
         [Fact]
         public void ParseDoubleNaNValues()
         {
-
             var json = @"
             {
                 ""00720076"": {
@@ -80,7 +79,6 @@ namespace FellowOakDicom.Tests.Serialization
                      ""Value"": [""NaN""]
                  }
             } ";
-
             var tagValue = JsonConvert.DeserializeObject<DicomDataset>(json, new CustomJsonDicomConverter());
             Assert.NotNull(tagValue);
             Assert.NotNull(tagValue.GetDicomItem<DicomFloatingPointSingle>(DicomTag.SelectorFLValue));

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -70,7 +70,7 @@ namespace FellowOakDicom.Tests.Serialization
         }
 
         [Fact]
-        public void ParseDoubleNaNValues()
+        public void ParseFloatingPointNaNValues()
         {
             var json = @"
             {
@@ -79,8 +79,7 @@ namespace FellowOakDicom.Tests.Serialization
                      ""Value"": [""NaN""]
                  }
             } ";
-            var tagValue = JsonConvert.DeserializeObject<DicomDataset>(json, new CustomJsonDicomConverter());
-            Assert.NotNull(tagValue);
+            var tagValue = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
             Assert.NotNull(tagValue.GetDicomItem<DicomFloatingPointSingle>(DicomTag.SelectorFLValue));
         }
 


### PR DESCRIPTION
Fixes # (https://github.com/fo-dicom/fo-dicom/issues/1063).

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Double.NaN values will be deserialized successfully successfully.
- For VR=FL  Value = "NaN", "Malformed Dicom Json" will not be thrown by JsonDicomConverter.
