### PR TITLE
Fixed the issue where Invalid DS values was causing upload to fail

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.7 (TBD)
+* Bug fix: DS VR type value ending with \0 fails to serialize (#1078)
 
 #### v.4.0.6 (8/6/2020)
 * Update to DICOM Standard 2020b.

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -504,6 +504,9 @@ namespace FellowOakDicom.Serialization
         /// <returns>A json number equivalent to the supplied DS value</returns>
         private static string FixDecimalString(string val)
         {
+            // trim invalid paaded character
+            val = val.Trim().TrimEnd('\0');
+
             if (IsValidJsonNumber(val))
             {
                 return val;

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -504,7 +504,7 @@ namespace FellowOakDicom.Serialization
         /// <returns>A json number equivalent to the supplied DS value</returns>
         private static string FixDecimalString(string val)
         {
-            // trim invalid paaded character
+            // trim invalid padded character
             val = val.Trim().TrimEnd('\0');
 
             if (IsValidJsonNumber(val))

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -948,6 +948,51 @@ namespace FellowOakDicom.Tests.Serialization
             Assert.Equal(ds.GetString(privTag2), ds2.GetString(privTag2));
         }
 
+        [Fact]
+        public static void GivenDicomDatasetWithInvalidPaddedCharacterForDecimalStringVRType_WhenSerialized_IsDeserializedCorrectly()
+        {
+            string invalidDSvalue = "0\0";
+
+            var dicomDataset = new DicomDataset();
+
+            //Disabling the validation to add the invalid VR datatype to a dicom dataset.
+#pragma warning disable CS0618 // Type or member is obsolete
+            dicomDataset.AutoValidate = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            dicomDataset.Add(DicomTag.Acceleration, invalidDSvalue);
+            
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            dicomDataset.AutoValidate = true;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var json = JsonConvert.SerializeObject(dicomDataset, new JsonDicomConverter());
+            JObject.Parse(json);
+            DicomDataset deserializedDataset = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var recoveredString = deserializedDataset.GetValue<string>(DicomTag.Acceleration, 0);
+            Assert.Equal("0", recoveredString);
+        }
+
+        [Fact]
+        public static void GivenDicomDatasetWithValidDecimalStringVRType_WhenSerialized_IsDeserializedCorrectly()
+        {
+            string invalidDSvalue = "97";
+
+            var dicomDataset = new DicomDataset
+            {
+                { DicomTag.Acceleration, invalidDSvalue },
+            };
+
+            var json = JsonConvert.SerializeObject(dicomDataset, new JsonDicomConverter());
+            JObject.Parse(json);
+            DicomDataset deserializedDataset = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var recoveredString = deserializedDataset.GetValue<string>(DicomTag.Acceleration, 0);
+            Assert.Equal("97", recoveredString);
+        }
+
+
+
 
         #region Sample Data
 

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -951,7 +951,7 @@ namespace FellowOakDicom.Tests.Serialization
         [Fact]
         public static void GivenDicomDatasetWithInvalidPaddedCharacterForDecimalStringVRType_WhenSerialized_IsDeserializedCorrectly()
         {
-            string invalidDSvalue = "0\0";
+            string invalidAccerationValue = "0\0";
 
             var dicomDataset = new DicomDataset();
 
@@ -960,7 +960,7 @@ namespace FellowOakDicom.Tests.Serialization
             dicomDataset.AutoValidate = false;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            dicomDataset.Add(DicomTag.Acceleration, invalidDSvalue);
+            dicomDataset.Add(DicomTag.Acceleration, invalidAccerationValue);
             
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -977,18 +977,18 @@ namespace FellowOakDicom.Tests.Serialization
         [Fact]
         public static void GivenDicomDatasetWithValidDecimalStringVRType_WhenSerialized_IsDeserializedCorrectly()
         {
-            string invalidDSvalue = "97";
+            string validAccelarationValue = "97";
 
             var dicomDataset = new DicomDataset
             {
-                { DicomTag.Acceleration, invalidDSvalue },
+                { DicomTag.Acceleration, validAccelarationValue },
             };
 
             var json = JsonConvert.SerializeObject(dicomDataset, new JsonDicomConverter());
             JObject.Parse(json);
             DicomDataset deserializedDataset = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
             var recoveredString = deserializedDataset.GetValue<string>(DicomTag.Acceleration, 0);
-            Assert.Equal("97", recoveredString);
+            Assert.Equal(validAccelarationValue, recoveredString);
         }
 
 


### PR DESCRIPTION
Fixes # [Bug 75008](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75008)

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Trim the invalid padded character "\0" in VR value for  for VR type = DS
- Added unit tests to verify the behavior

